### PR TITLE
Make CreateCase and UpdateCase support setting 'language' field

### DIFF
--- a/lib/Desk/service-description/models/Case.group/CaseModel.yaml
+++ b/lib/Desk/service-description/models/Case.group/CaseModel.yaml
@@ -8,6 +8,7 @@ properties:
     type:          { extends: CaseModel.type }
     labels:        { extends: CaseModel.labels }
     custom_fields: { extends: CaseModel.custom_fields }
+    language:      { extends: CaseModel.language }
     created_at:    { extends: CaseModel.created_at.output }
     updated_at:    { extends: CaseModel.updated_at.output }
     active_at:     { extends: CaseModel.active_at.output }

--- a/lib/Desk/service-description/models/Case.group/__index.yaml
+++ b/lib/Desk/service-description/models/Case.group/__index.yaml
@@ -25,6 +25,9 @@ CaseModel.labels:
 CaseModel.custom_fields:
     extends: custom_fields
     description: Hash of values for custom fields
+CaseModel.language:
+    extends: language
+    description: Language of the case
 CaseModel.created_at.output:
     extends: date.output
     description: Time of creation

--- a/lib/Desk/service-description/models/__index.yaml
+++ b/lib/Desk/service-description/models/__index.yaml
@@ -8,6 +8,9 @@ custom_fields:
     extends: parameter
     type: object
     additionalProperties: true
+language:
+    extends: parameter
+    type: string
 date.output:
     extends: parameter
     type: string

--- a/lib/Desk/service-description/operations/Case.group/CreateCase.yaml
+++ b/lib/Desk/service-description/operations/Case.group/CreateCase.yaml
@@ -11,6 +11,7 @@ parameters:
     type:          { extends: CaseModel.type, required: true }
     labels:        { extends: CaseModel.labels }
     custom_fields: { extends: CaseModel.custom_fields }
+    language:      { extends: CaseModel.language }
     created_at:    { extends: CaseModel.created_at.input }
     updated_at:    { extends: CaseModel.updated_at.input }
     active_at:     { extends: CaseModel.active_at.input }

--- a/lib/Desk/service-description/operations/Case.group/UpdateCase.yaml
+++ b/lib/Desk/service-description/operations/Case.group/UpdateCase.yaml
@@ -11,6 +11,7 @@ parameters:
     type:          { extends: CaseModel.type }
     labels:        { extends: CaseModel.labels }
     custom_fields: { extends: CaseModel.custom_fields }
+    language:      { extends: CaseModel.language }
     created_at:    { extends: CaseModel.created_at.output }
     updated_at:    { extends: CaseModel.updated_at.output }
     active_at:     { extends: CaseModel.active_at.output }

--- a/tests/Desk/Test/Operation/Cases/CreateCaseOperationTest.php
+++ b/tests/Desk/Test/Operation/Cases/CreateCaseOperationTest.php
@@ -35,6 +35,7 @@ class CreateCaseOperationTest extends CreateOperationTestCase
             'priority' => 4,
             'status' => 'open',
             'labels' => array('Spam', 'Ignore'),
+            'language' => 'en',
             'created_at' => $date,
             'customer_id' => 1,
             'assigned_user_id' => 1,
@@ -139,6 +140,7 @@ class CreateCaseOperationTest extends CreateOperationTestCase
         $this->assertNull($case->get('active_at'));
         $this->assertInstanceOf('DateTime', $case->get('received_at'));
         $this->assertSame(1335994728, $case->get('received_at')->getTimestamp());
+        $this->assertSame('en', $case->get('language'));
     }
 
     /**

--- a/tests/Desk/Test/Operation/Cases/UpdateCaseOperationTest.php
+++ b/tests/Desk/Test/Operation/Cases/UpdateCaseOperationTest.php
@@ -30,6 +30,7 @@ class UpdateCaseOperationTest extends UpdateOperationTestCase
             'subject' => 'Welcome',
             'type' => 'email',
             'status' => 'closed',
+            'language' => 'en',
         );
     }
 
@@ -75,6 +76,7 @@ class UpdateCaseOperationTest extends UpdateOperationTestCase
         $this->assertSame(1335994728, $case->get('updated_at')->getTimestamp());
         $this->assertInstanceOf('DateTime', $case->get('received_at'));
         $this->assertSame(1335994728, $case->get('received_at')->getTimestamp());
+        $this->assertSame('en', $case->get('language'));
     }
 
     /**


### PR DESCRIPTION
- [x] CR @karoun || @jeffchan 
- [x] QA @joshrai

The Desk API supports updating a case's language (despite it being absent from their [docs](http://dev.desk.com/API/cases/#update) -- Desk tech support [confirmed this](https://support.desk.com/customer/en/portal/private/cases/1017077?b_id=7112) and I confirmed locally.

This wasn't working when we used the desk-php library, and it looks like that library just didn't have that field mapped in its Guzzle service definition. This is an attempt to fix that.

I haven't actually run the unit tests yet, but I tested this manually.